### PR TITLE
update readme now that all the dependencies exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,24 +12,10 @@ This package is new, but should be "working" to a greater or lesser extent in al
 
 ### Install
 
-Currently InteractNext is not in metadata, and neither are a few packages it is built on, so for now installation is:
+Currently InteractNext is not in metadata, so for now installation is:
 ```
-Pkg.clone("https://github.com/JuliaGizmos/WebIO.jl")
-Pkg.checkout("Observables")
-Pkg.clone("https://github.com/JuliaGizmos/Vue.jl")
-Pkg.clone("https://github.com/JuliaGizmos/CSSUtil.jl")
 Pkg.clone("https://github.com/JuliaGizmos/InteractNext.jl")
 ```
-If you have those packages already, you'll want to ensure they're on master too, since they're under development atm, so `Pkg.update()` to ensure you're up to date.
-
-Until a proper WebIO release is made, we will need to run a couple of further steps. Firstly [node.js](https://nodejs.org/en/) will need to be installed. And then, run these at a Julia prompt:
-```
-using WebIO
-WebIO.devsetup()
-WebIO.bundlejs(watch=false)
-```
-
-N.b. the above are just a one-off requirement to install WebIO's javascript files. See [WebIO](https://github.com/JuliaGizmos/WebIO.jl) for more details.
 
 ### Examples
 
@@ -37,7 +23,7 @@ The following code is common to the examples below. It creates some svg circle e
 whose centres are sampled from a sine wave.
 
 ```julia
-using InteractNext
+using InteractNext, WebIO
 
 width, height = 700, 300
 colors = ["black", "gray", "silver", "maroon", "red", "olive", "yellow", "green", "lime", "teal", "aqua", "navy", "blue", "purple", "fuchsia"]

--- a/README.md
+++ b/README.md
@@ -115,10 +115,7 @@ and when you click on a button, or move the slider, the plot should update.
 
 #### IJulia
 ```julia
-display.((mp,p));
-# or
-p.displayed = true # needed until PlotlyJS.jl is better integrated with WebIO.jl
-display(ui);
+display.((mp,p)); # needed until PlotlyJS.jl is better integrated with WebIO.jl
 ```
 
 #### Blink (from the REPL)

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,8 @@
-WebIO 0.1.4
-Observables
+WebIO 0.1.9
+Observables 0.1
 Requires
 DataStructures
 JSON
-Vue
-JSExpr
+Vue 0.1
+JSExpr 0.1.1
+CSSUtil 0.0.1


### PR DESCRIPTION
Towards #14 

I just tested it out, and the basic InteractNext demos work (at least in IJulia and Blink) using only released versions of all the dependencies, so all of the `Pkg.clone()` and `Pkg.checkout()` steps should no longer be needed. Also, installing Node and building the WebIO JS bundle is no longer necessary. Basically, I think this is good to go for a first release! 